### PR TITLE
add GITEA_USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ First, setup your environment variables like this:
 export ACCESS_TOKEN=123
 export GITEA_URL=https://gitea.example.com
 export GITHUB_TOKEN=456
+export GITEA_USER=789
 ```
 
 There are four modes of operation, which the script can print out to the console:

--- a/github2gitea-mirror
+++ b/github2gitea-mirror
@@ -17,6 +17,7 @@
 #   ACCESS_TOKEN = Gitea token
 #   GITERA_URL   = Gitea URL
 #   GITHUB_TOKEN = GitHub personal access token
+#   GITEA_USER   = Which user creates the repository
 
 # Displays the given input including "=> " on the console.
 log () {
@@ -114,7 +115,11 @@ set_uid() {
 
 # Sets the uid to the specified Gitea user
 set_uid_user() {
-    uid=$($CURL "${header_options[@]}" $GITEA_URL/api/v1/users/${github_user} | jq .id)
+    if [[ -z "${GITEA_USER}" ]]; then
+        uid=$($CURL "${header_options[@]}" $GITEA_URL/api/v1/users/${github_user} | jq .id)
+    else
+        uid=$($CURL "${header_options[@]}" $GITEA_URL/api/v1/users/${GITEA_USER} | jq .id)
+    fi  
 }
 
 # Fetches all starred repos of the given user to JSON files


### PR DESCRIPTION
I added the `GITEA_USER` parameter, which allows you to specify the user under whose name repositories will be created.
If the value is missing, a user will be created according to the name on `github`.
I think this function is useful, it will allow you to separate mirrors and local repositories.